### PR TITLE
🔧 Fix wagmi v1 hooks compatibility in useRedPacket.js

### DIFF
--- a/web-connectkit/src/hooks/useRedPacket.js
+++ b/web-connectkit/src/hooks/useRedPacket.js
@@ -1,10 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { 
-  useAccount, 
-  useReadContract, 
-  useWriteContract, 
-  useWaitForTransactionReceipt 
-} from 'wagmi';
+import { useAccount, useContractRead, useContractWrite, usePrepareContractWrite, useWaitForTransaction } from 'wagmi';
 import { CONTRACT_ADDRESS, CONTRACT_ABI } from '../contracts/ChaleeDApp';
 import { parseEth, formatEth, getErrorMessage, validateRedPacketParams, debugLog } from '../utils/helpers';
 
@@ -18,34 +13,176 @@ export function useRedPacket() {
   const [queryError, setQueryError] = useState('');
 
   // 获取合约所有者
-  const { data: owner } = useReadContract({
+  const { data: owner } = useContractRead({
     address: CONTRACT_ADDRESS,
     abi: CONTRACT_ABI,
     functionName: 'owner',
   });
 
   // 获取合约余额
-  const { data: balance, refetch: refetchBalance } = useReadContract({
+  const { data: balance, refetch: refetchBalance } = useContractRead({
     address: CONTRACT_ADDRESS,
     abi: CONTRACT_ABI,
     functionName: 'getBalance',
   });
 
   // 获取最新红包ID
-  const { data: packetId, refetch: refetchPacketId } = useReadContract({
+  const { data: packetId, refetch: refetchPacketId } = useContractRead({
     address: CONTRACT_ADDRESS,
     abi: CONTRACT_ABI,
     functionName: 'packetId',
   });
 
   // 获取用户信息
-  const { data: info, refetch: refetchUserInfo } = useReadContract({
+  const { data: info, refetch: refetchUserInfo } = useContractRead({
     address: CONTRACT_ADDRESS,
     abi: CONTRACT_ABI,
     functionName: 'getInfo',
-    query: {
-      enabled: isConnected,
-    }
+    enabled: isConnected,
+  });
+
+  // 创建红包配置
+  const [createConfig, setCreateConfig] = useState(null);
+  const { config: createRedPacketConfig } = usePrepareContractWrite({
+    address: CONTRACT_ADDRESS,
+    abi: CONTRACT_ABI,
+    functionName: 'sendRedPacket',
+    args: createConfig?.args,
+    value: createConfig?.value,
+    enabled: !!createConfig,
+  });
+
+  const {
+    write: writeCreateRedPacket,
+    data: createData,
+    isLoading: isCreating,
+    error: createError,
+  } = useContractWrite(createRedPacketConfig);
+
+  const {
+    isLoading: isCreatePending,
+    isSuccess: isCreateSuccess,
+  } = useWaitForTransaction({
+    hash: createData?.hash,
+  });
+
+  // 抢红包配置
+  const [grabConfig, setGrabConfig] = useState(null);
+  const { config: grabRedPacketConfig } = usePrepareContractWrite({
+    address: CONTRACT_ADDRESS,
+    abi: CONTRACT_ABI,
+    functionName: 'getRedPacket',
+    args: grabConfig?.args,
+    enabled: !!grabConfig,
+  });
+
+  const {
+    write: writeGrabRedPacket,
+    data: grabData,
+    isLoading: isGrabbing,
+    error: grabError,
+  } = useContractWrite(grabRedPacketConfig);
+
+  const {
+    isLoading: isGrabPending,
+    isSuccess: isGrabSuccess,
+  } = useWaitForTransaction({
+    hash: grabData?.hash,
+  });
+
+  // 存款配置
+  const [depositConfig, setDepositConfig] = useState(null);
+  const { config: depositContractConfig } = usePrepareContractWrite({
+    address: CONTRACT_ADDRESS,
+    abi: CONTRACT_ABI,
+    functionName: 'deposit',
+    value: depositConfig?.value,
+    enabled: !!depositConfig,
+  });
+
+  const {
+    write: writeDeposit,
+    data: depositData,
+    isLoading: isDepositing,
+    error: depositError,
+  } = useContractWrite(depositContractConfig);
+
+  const {
+    isLoading: isDepositPending,
+    isSuccess: isDepositSuccess,
+  } = useWaitForTransaction({
+    hash: depositData?.hash,
+  });
+
+  // 提款配置
+  const [withdrawConfig, setWithdrawConfig] = useState(null);
+  const { config: withdrawContractConfig } = usePrepareContractWrite({
+    address: CONTRACT_ADDRESS,
+    abi: CONTRACT_ABI,
+    functionName: 'withdraw',
+    args: withdrawConfig?.args,
+    enabled: !!withdrawConfig,
+  });
+
+  const {
+    write: writeWithdraw,
+    data: withdrawData,
+    isLoading: isWithdrawing,
+    error: withdrawError,
+  } = useContractWrite(withdrawContractConfig);
+
+  const {
+    isLoading: isWithdrawPending,
+    isSuccess: isWithdrawSuccess,
+  } = useWaitForTransaction({
+    hash: withdrawData?.hash,
+  });
+
+  // 设置用户信息配置
+  const [setInfoConfig, setSetInfoConfig] = useState(null);
+  const { config: setInfoContractConfig } = usePrepareContractWrite({
+    address: CONTRACT_ADDRESS,
+    abi: CONTRACT_ABI,
+    functionName: 'setInfo',
+    args: setInfoConfig?.args,
+    enabled: !!setInfoConfig,
+  });
+
+  const {
+    write: writeSetInfo,
+    data: setInfoData,
+    isLoading: isSettingInfo,
+    error: setInfoError,
+  } = useContractWrite(setInfoContractConfig);
+
+  const {
+    isLoading: isSetInfoPending,
+    isSuccess: isSetInfoSuccess,
+  } = useWaitForTransaction({
+    hash: setInfoData?.hash,
+  });
+
+  // 转移到所有者配置
+  const [transferConfig, setTransferConfig] = useState(null);
+  const { config: transferContractConfig } = usePrepareContractWrite({
+    address: CONTRACT_ADDRESS,
+    abi: CONTRACT_ABI,
+    functionName: 'transferToOwner',
+    enabled: !!transferConfig,
+  });
+
+  const {
+    write: writeTransferToOwner,
+    data: transferData,
+    isLoading: isTransferring,
+    error: transferError,
+  } = useContractWrite(transferContractConfig);
+
+  const {
+    isLoading: isTransferPending,
+    isSuccess: isTransferSuccess,
+  } = useWaitForTransaction({
+    hash: transferData?.hash,
   });
 
   // 查询红包信息的 hook - 使用动态参数
@@ -55,82 +192,18 @@ export function useRedPacket() {
     isLoading: isQueryingPacket,
     error: packetQueryError,
     refetch: refetchPacketInfo 
-  } = useReadContract({
+  } = useContractRead({
     address: CONTRACT_ADDRESS,
     abi: CONTRACT_ABI,
     functionName: 'getPacketInfo',
     args: [packetQueryId],
-    query: {
-      enabled: isConnected && packetQueryId >= 0,
+    enabled: isConnected && packetQueryId >= 0,
+    onError: (error) => {
+      debugLog('查询红包信息失败', { packetQueryId, error: error.message });
+    },
+    onSuccess: (data) => {
+      debugLog('查询红包信息成功', { packetQueryId, data });
     }
-  });
-
-  // 写入合约的 hooks
-  const { 
-    writeContract: writeCreateRedPacket,
-    data: createData,
-    isPending: isCreating,
-    error: createError,
-  } = useWriteContract();
-
-  const { 
-    writeContract: writeGrabRedPacket,
-    data: grabData,
-    isPending: isGrabbing,
-    error: grabError,
-  } = useWriteContract();
-
-  const { 
-    writeContract: writeDeposit,
-    data: depositData,
-    isPending: isDepositing,
-    error: depositError,
-  } = useWriteContract();
-
-  const { 
-    writeContract: writeWithdraw,
-    data: withdrawData,
-    isPending: isWithdrawing,
-    error: withdrawError,
-  } = useWriteContract();
-
-  const { 
-    writeContract: writeSetInfo,
-    data: setInfoData,
-    isPending: isSettingInfo,
-    error: setInfoError,
-  } = useWriteContract();
-
-  const { 
-    writeContract: writeTransferToOwner,
-    data: transferData,
-    isPending: isTransferring,
-    error: transferError,
-  } = useWriteContract();
-
-  // 等待交易确认的 hooks
-  const { isLoading: isCreatePending, isSuccess: isCreateSuccess } = useWaitForTransactionReceipt({
-    hash: createData,
-  });
-
-  const { isLoading: isGrabPending, isSuccess: isGrabSuccess } = useWaitForTransactionReceipt({
-    hash: grabData,
-  });
-
-  const { isLoading: isDepositPending, isSuccess: isDepositSuccess } = useWaitForTransactionReceipt({
-    hash: depositData,
-  });
-
-  const { isLoading: isWithdrawPending, isSuccess: isWithdrawSuccess } = useWaitForTransactionReceipt({
-    hash: withdrawData,
-  });
-
-  const { isLoading: isSetInfoPending, isSuccess: isSetInfoSuccess } = useWaitForTransactionReceipt({
-    hash: setInfoData,
-  });
-
-  const { isLoading: isTransferPending, isSuccess: isTransferSuccess } = useWaitForTransactionReceipt({
-    hash: transferData,
   });
 
   // 更新状态 effects
@@ -199,7 +272,7 @@ export function useRedPacket() {
     }
   }, [packetQueryError, packetQueryId]);
 
-  // 查询红包函数
+  // 查询红包函数 - 修复版本
   const queryRedPacket = useCallback(async (packetIdValue) => {
     try {
       debugLog('开始查询红包', { packetIdValue, currentPacketId: Number(packetId) });
@@ -223,7 +296,7 @@ export function useRedPacket() {
       setQueryError('');
       setRedPacketInfo(null);
       
-      // 设置要查询的ID，这会触发 useReadContract
+      // 设置要查询的ID，这会触发 useContractRead
       setCurrentPacketId(packetIdValue);
       setPacketQueryId(packetIdValue);
       
@@ -262,13 +335,17 @@ export function useRedPacket() {
       const amountWei = parseEth(amount);
       debugLog('创建红包参数', { amount, count, isEqual, amountWei: amountWei.toString() });
       
-      await writeCreateRedPacket({
-        address: CONTRACT_ADDRESS,
-        abi: CONTRACT_ABI,
-        functionName: 'sendRedPacket',
+      setCreateConfig({
         args: [isEqual, count, amountWei],
         value: amountWei,
       });
+      
+      // 等待 config 更新后再调用 write
+      setTimeout(() => {
+        if (writeCreateRedPacket) {
+          writeCreateRedPacket();
+        }
+      }, 100);
     } catch (error) {
       console.error('创建红包失败:', error);
       throw new Error(getErrorMessage(error));
@@ -293,12 +370,15 @@ export function useRedPacket() {
 
       debugLog('抢红包', { currentPacketId });
       
-      await writeGrabRedPacket({
-        address: CONTRACT_ADDRESS,
-        abi: CONTRACT_ABI,
-        functionName: 'getRedPacket',
+      setGrabConfig({
         args: [currentPacketId],
       });
+      
+      setTimeout(() => {
+        if (writeGrabRedPacket) {
+          writeGrabRedPacket();
+        }
+      }, 100);
     } catch (error) {
       console.error('抢红包失败:', error);
       throw new Error(getErrorMessage(error));
@@ -315,12 +395,15 @@ export function useRedPacket() {
       const amountWei = parseEth(amount);
       debugLog('存款', { amount, amountWei: amountWei.toString() });
       
-      await writeDeposit({
-        address: CONTRACT_ADDRESS,
-        abi: CONTRACT_ABI,
-        functionName: 'deposit',
+      setDepositConfig({
         value: amountWei,
       });
+      
+      setTimeout(() => {
+        if (writeDeposit) {
+          writeDeposit();
+        }
+      }, 100);
     } catch (error) {
       console.error('存款失败:', error);
       throw new Error(getErrorMessage(error));
@@ -337,12 +420,15 @@ export function useRedPacket() {
       const amountWei = parseEth(amount);
       debugLog('提款', { amount, amountWei: amountWei.toString() });
       
-      await writeWithdraw({
-        address: CONTRACT_ADDRESS,
-        abi: CONTRACT_ABI,
-        functionName: 'withdraw',
+      setWithdrawConfig({
         args: [amountWei],
       });
+      
+      setTimeout(() => {
+        if (writeWithdraw) {
+          writeWithdraw();
+        }
+      }, 100);
     } catch (error) {
       console.error('提款失败:', error);
       throw new Error(getErrorMessage(error));
@@ -358,12 +444,15 @@ export function useRedPacket() {
       
       debugLog('设置用户信息', { name, age });
       
-      await writeSetInfo({
-        address: CONTRACT_ADDRESS,
-        abi: CONTRACT_ABI,
-        functionName: 'setInfo',
+      setSetInfoConfig({
         args: [name, age],
       });
+      
+      setTimeout(() => {
+        if (writeSetInfo) {
+          writeSetInfo();
+        }
+      }, 100);
     } catch (error) {
       console.error('设置用户信息失败:', error);
       throw new Error(getErrorMessage(error));
@@ -374,12 +463,13 @@ export function useRedPacket() {
   const transferToOwner = async () => {
     try {
       debugLog('转移到所有者');
+      setTransferConfig({ enabled: true });
       
-      await writeTransferToOwner({
-        address: CONTRACT_ADDRESS,
-        abi: CONTRACT_ABI,
-        functionName: 'transferToOwner',
-      });
+      setTimeout(() => {
+        if (writeTransferToOwner) {
+          writeTransferToOwner();
+        }
+      }, 100);
     } catch (error) {
       console.error('转移失败:', error);
       throw new Error(getErrorMessage(error));
@@ -405,6 +495,7 @@ export function useRedPacket() {
       setTimeout(() => {
         autoQueryLatestPacket();
       }, 2000); // 等待2秒让区块确认
+      setCreateConfig(null);
     }
   }, [isCreateSuccess, refreshData, autoQueryLatestPacket]);
 
@@ -417,6 +508,7 @@ export function useRedPacket() {
           queryRedPacket(currentPacketId);
         }, 2000); // 等待2秒让区块确认
       }
+      setGrabConfig(null);
     }
   }, [isGrabSuccess, currentPacketId, queryRedPacket, refreshData]);
 
@@ -424,6 +516,9 @@ export function useRedPacket() {
     if (isDepositSuccess || isWithdrawSuccess || isTransferSuccess) {
       debugLog('余额操作成功', { isDepositSuccess, isWithdrawSuccess, isTransferSuccess });
       refreshData();
+      setDepositConfig(null);
+      setWithdrawConfig(null);
+      setTransferConfig(null);
     }
   }, [isDepositSuccess, isWithdrawSuccess, isTransferSuccess, refreshData]);
 
@@ -431,6 +526,7 @@ export function useRedPacket() {
     if (isSetInfoSuccess) {
       debugLog('用户信息设置成功');
       refetchUserInfo();
+      setSetInfoConfig(null);
     }
   }, [isSetInfoSuccess, refetchUserInfo]);
 


### PR DESCRIPTION
## 🔧 修复 wagmi v1 Hooks 兼容性

修复了 `useRedPacket.js` 中使用错误的 wagmi v2 API 导致的编译错误。

### 🐛 问题描述

在前一次修复中，虽然我们将依赖回滚到了 wagmi v1，但 `useRedPacket.js` 文件仍然使用的是 wagmi v2 的 API，导致以下错误：

- `export 'useReadContract' was not found in 'wagmi'`
- `export 'useWriteContract' was not found in 'wagmi'`
- `export 'useWaitForTransactionReceipt' was not found in 'wagmi'`

### ✅ 修复内容

#### 📦 API 替换映射
- `useReadContract` → `useContractRead` (wagmi v1)
- `useWriteContract` → `useContractWrite` + `usePrepareContractWrite` (wagmi v1)
- `useWaitForTransactionReceipt` → `useWaitForTransaction` (wagmi v1)

#### 🔧 具体修复

1. **读取合约数据**:
   ```javascript
   // 旧的 v2 API
   const { data } = useReadContract({ ... });
   
   // 新的 v1 API
   const { data } = useContractRead({ ... });
   ```

2. **写入合约数据**:
   ```javascript
   // 旧的 v2 API
   const { writeContract } = useWriteContract();
   
   // 新的 v1 API
   const { config } = usePrepareContractWrite({ ... });
   const { write } = useContractWrite(config);
   ```

3. **等待交易确认**:
   ```javascript
   // 旧的 v2 API
   const { isLoading } = useWaitForTransactionReceipt({ hash });
   
   // 新的 v1 API
   const { isLoading } = useWaitForTransaction({ hash: data?.hash });
   ```

#### 🎯 保持的功能
- ✅ 所有红包功能保持不变
- ✅ 创建、抢夺、查询红包
- ✅ 存款、提款操作
- ✅ 用户信息管理
- ✅ 所有者权限控制
- ✅ 实时状态更新

### 🧪 预期结果

修复后应用将：
- ✅ 编译成功，没有错误
- ✅ 钱包连接正常
- ✅ 所有合约交互功能正常
- ✅ ConnectKit 界面正常显示

### 📋 测试建议

```bash
# 清理并重新安装依赖
rm -rf node_modules package-lock.json
npm install

# 启动应用
npm start
```

现在应用应该能够正常启动并完全正常工作！